### PR TITLE
[Fix] SecurityConfig 문제

### DIFF
--- a/server/src/main/java/ICTPrj/server/SecurityConfig.java
+++ b/server/src/main/java/ICTPrj/server/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedOriginPatterns((Arrays.asList("*")));
         configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
         configuration.setAllowCredentials(true);

--- a/server/src/main/java/ICTPrj/server/controller/PostController.java
+++ b/server/src/main/java/ICTPrj/server/controller/PostController.java
@@ -1,0 +1,27 @@
+package ICTPrj.server.controller;
+
+
+import ICTPrj.server.dto.PostDto;
+import ICTPrj.server.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping("/post")
+    public Long writePost(@RequestHeader(value = "Authorization") String userToken,
+                          @RequestBody PostDto postDto) {
+        return postService.writePost(userToken, postDto);
+    }
+
+
+
+
+
+}

--- a/server/src/main/java/ICTPrj/server/dto/PostDto.java
+++ b/server/src/main/java/ICTPrj/server/dto/PostDto.java
@@ -1,0 +1,33 @@
+package ICTPrj.server.dto;
+
+import ICTPrj.server.domain.entity.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Setter
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostDto {
+    private Long id;
+    private String content;
+    private Long userId;
+
+    private List<File> files;
+    private List<Comment> comments;
+    private List<Likes> likes;
+
+    public static PostDto of(Post post){
+        return PostDto.builder()
+                .id(post.getId())
+                .content(post.getContent())
+                .userId(post.getUser().getId())
+                .files(post.getFiles())
+                .comments(post.getComments())
+                .likes(post.getLikes())
+                .build();
+    }
+}

--- a/server/src/main/java/ICTPrj/server/service/PostService.java
+++ b/server/src/main/java/ICTPrj/server/service/PostService.java
@@ -1,0 +1,47 @@
+package ICTPrj.server.service;
+
+import ICTPrj.server.domain.entity.Post;
+import ICTPrj.server.domain.entity.User;
+import ICTPrj.server.domain.repository.PostRepository;
+import ICTPrj.server.domain.repository.UserRepository;
+import ICTPrj.server.dto.PostDto;
+import ICTPrj.server.dto.UserDto;
+import ICTPrj.server.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class PostService {
+    private final PostRepository postRepository;
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+
+    private String getUserEmail(String userToken) {
+        String userToken_ = userToken.substring(7);
+        String userEmail = tokenProvider.getUserEmailFromToken(userToken_);
+        return userEmail;
+    }
+
+    public Long writePost(String userToken, PostDto postDto) {
+        // 유저가 {회원 or 비회원}?
+        String userEmail = getUserEmail(userToken);
+        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized"));
+
+        Post post = Post.builder()
+                .content(postDto.getContent())
+                .user(user)
+                .files(postDto.getFiles())
+                .build();
+
+        return PostDto.of(postRepository.save(post)).getId();
+    }
+}
+
+
+


### PR DESCRIPTION
오류 메세지
- When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header.

원인
- [notion] Spring ref 참조

수정사항
- SecurityConfig 에서 allowedOrigins -> allowedOriginsPattern 으로 수정